### PR TITLE
Use enriched names for Foundation Foods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/gatsby-types.d.ts
 .vscode
 data
 wget-log*
+.raw

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "npm run download-data && gatsby develop",
-    "build": "npm run download-data && gatsby build",
+    "build": "npm run download-data && NODE_OPTIONS=--max-old-space-size=8192 gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "typecheck": "tsc --noEmit",

--- a/src/components/AutoCompleteSearch/AutoCompleteSearch.tsx
+++ b/src/components/AutoCompleteSearch/AutoCompleteSearch.tsx
@@ -133,6 +133,7 @@ function AutoCompleteSearch(
     if (props.searchLocation !== "") {
       const searchData: SearchParams = {
         name: item.name,
+        hap_name: item.hap_name,
         category: item.category,
         timestamp: new Date(),
         searchLocation: props.searchLocation ?? "Food",
@@ -169,7 +170,7 @@ function AutoCompleteSearch(
 
   useEffect(() => {
     async function fetchData() {
-      const searches = (await fetchRecentSearches()).reverse();
+      const searches = await (await fetchRecentSearches()).reverse();
       setRecentSearches(searches as SearchParams[]);
     }
     fetchData();

--- a/src/components/AutoCompleteSearch/AutoCompleteSearch.tsx
+++ b/src/components/AutoCompleteSearch/AutoCompleteSearch.tsx
@@ -46,6 +46,7 @@ type AutocompleteItem = Hit<{
   category: any;
   image: string;
   name: string;
+  hap_name: string;
   objectID: string;
   url: string;
 }>;
@@ -168,7 +169,7 @@ function AutoCompleteSearch(
 
   useEffect(() => {
     async function fetchData() {
-      const searches = await (await fetchRecentSearches()).reverse();
+      const searches = (await fetchRecentSearches()).reverse();
       setRecentSearches(searches as SearchParams[]);
     }
     fetchData();

--- a/src/components/SearchResults/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SearchResults/SearchResultItem/SearchResultItem.tsx
@@ -53,7 +53,7 @@ export default function SearchResultItem({ item, onSelectItem, multiple }: Searc
                   fontWeight: theme.typography.fontWeightLight,
                 }}
               >
-                {item.name}
+                {item.hap_name}
               </Typography>
             </Box>
           }

--- a/src/generators/DetailsPageGenerator.ts
+++ b/src/generators/DetailsPageGenerator.ts
@@ -1,3 +1,5 @@
+import { writeJsonToFile } from "../helpers/shared";
+
 const path = require("path");
 const ff_nutrition_facts = require("../../data/foundation_food_nutrition_facts.json");
 const sr_legacy_nutrition_facts = require("../../data/sr_legacy_food_nutrition_facts.json");
@@ -33,8 +35,14 @@ export const createDetailsPage = (createPage: any) => {
   }
 };
 
-const createNutritionTable = ({ createPageFunction, foods }: any) => {
-  let ffSearchIndex: any = [];
+interface SearchIndexEntry {
+  name: string;
+  hap_name: string;
+  category: string;
+  url: string;
+}
+const createNutritionTable = ({ createPageFunction, foods, indexFileName }: any) => {
+  let ffSearchIndex: SearchIndexEntry[] = [];
   const template = path.resolve("src/templates/DetailsPage.tsx");
   foods.forEach((food: Food) => {
     if (food.name) {
@@ -44,7 +52,8 @@ const createNutritionTable = ({ createPageFunction, foods }: any) => {
       const carbohydrates = filterNutrient(food, CARBOHYDRATE_NAME, CARBOHYDRATE_UNIT);
       const protein = filterNutrient(food, PROTEIN_NAME, PROTEIN_UNIT);
       const seoInfo = generateSEOInfo(food.name, calories, protein, carbohydrates, fat);
-      const pagePath = spaceToDashes(food["name"].toString());
+      const foodName = indexFileName === "ff_search_index" ? food.hap_name : food.name; // todo: until the point when we have SR Legacy name clean up
+      const pagePath = spaceToDashes(foodName);
       const seo: { title: string; description: string; pagePath: string } = {
         title: seoInfo.title,
         description: seoInfo.description,
@@ -61,9 +70,11 @@ const createNutritionTable = ({ createPageFunction, foods }: any) => {
       });
       ffSearchIndex.push({
         name: food.name,
+        hap_name: foodName,
         category: food.category,
         url: `/${pagePath}`,
       });
+      writeJsonToFile(`${indexFileName}.json`, ffSearchIndex);
     }
   });
 };

--- a/src/generators/DetailsPageGenerator.ts
+++ b/src/generators/DetailsPageGenerator.ts
@@ -53,7 +53,7 @@ const createNutritionTable = ({ createPageFunction, foods, indexFileName }: any)
       const protein = filterNutrient(food, PROTEIN_NAME, PROTEIN_UNIT);
       const seoInfo = generateSEOInfo(food.name, calories, protein, carbohydrates, fat);
       const foodName = indexFileName === "ff_search_index" ? food.hap_name : food.name; // todo: until the point when we have SR Legacy name clean up
-      const pagePath = spaceToDashes(foodName);
+      const pagePath = spaceToDashes(food.name);
       const seo: { title: string; description: string; pagePath: string } = {
         title: seoInfo.title,
         description: seoInfo.description,
@@ -74,7 +74,7 @@ const createNutritionTable = ({ createPageFunction, foods, indexFileName }: any)
         category: food.category,
         url: `/${pagePath}`,
       });
-      writeJsonToFile(`${indexFileName}.json`, ffSearchIndex);
     }
   });
+  writeJsonToFile(`${indexFileName}.json`, ffSearchIndex);
 };

--- a/src/helpers/forkfacts-recent-searches.ts
+++ b/src/helpers/forkfacts-recent-searches.ts
@@ -6,6 +6,7 @@ interface DBData extends DBSchema {
     value: {
       timestamp: Date;
       name: string;
+      hap_name: string;
       category: string;
       searchLocation: string;
       searchId?: string;
@@ -17,6 +18,7 @@ interface DBData extends DBSchema {
 
 export interface SearchParams {
   name: string;
+  hap_name: string;
   category: string;
   timestamp: Date;
   searchLocation: string;

--- a/src/helpers/shared.ts
+++ b/src/helpers/shared.ts
@@ -1,0 +1,10 @@
+import * as fs from "fs";
+
+const ARTIFACT_PATH = ".raw";
+export const writeJsonToFile = (fileName: string, jsonData: any[]) => {
+  if (!fs.existsSync(ARTIFACT_PATH)) fs.mkdirSync(ARTIFACT_PATH);
+  fs.writeFile(`${ARTIFACT_PATH}/${fileName}`, JSON.stringify(jsonData), (err: any) => {
+    if (err) throw err;
+    console.log(`Done writing to file ${fileName}`);
+  });
+};

--- a/src/models/components.d.ts
+++ b/src/models/components.d.ts
@@ -5,6 +5,7 @@ import { SVGProps } from "react";
 
 export interface SearchResultItemType {
   name: string;
+  hap_name: string;
   url: string;
   image: string;
   category: string;

--- a/src/models/pages.d.ts
+++ b/src/models/pages.d.ts
@@ -76,6 +76,7 @@ export type NutrientItem = {
 export interface Food {
   category: string;
   name: string;
+  hap_name: string;
   fdcId: number;
   nutrients: {
     amount: number;

--- a/src/templates/DetailsPage.tsx
+++ b/src/templates/DetailsPage.tsx
@@ -202,7 +202,7 @@ const DetailsPageTemplate = ({ pageContext }: PageProps) => {
           menuItems={menuItems}
           foodsWithSameNames={[]}
           foodOverview={{
-            name: food.name,
+            name: food.hap_name !== "" ? food.hap_name : food.name, // todo: changes when SR Legacy has updated name
             category: food.category,
           }}
           tabItems={tabItems}


### PR DESCRIPTION
## Changes
1. Update search index to include `hap_name` which indicates enriched name for foods. This has been cleaned for Foundation Foods. For SR Legacy, `name = hap_name` for now. This has happened behind the scenes, no changes in this PR
2. Display enriched name in search results
3. Update Recent Searches to use enriched name